### PR TITLE
Fix form generics and update server types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.DS_Store

--- a/client/src/components/ui/form.tsx
+++ b/client/src/components/ui/form.tsx
@@ -30,10 +30,11 @@ const FormFieldContext = React.createContext<FormFieldContextValue>(
 
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+  TTransformedValues extends FieldValues = TFieldValues
 >({
   ...props
-}: ControllerProps<TFieldValues, TName>) => {
+}: ControllerProps<TFieldValues, TName, TTransformedValues>) => {
   return (
     <FormFieldContext.Provider value={{ name: props.name }}>
       <Controller {...props} />


### PR DESCRIPTION
## Summary
- Expand FormField generics to support transformed values with latest react-hook-form
- Normalize server storage models and type conversions for menu items, events, and games
- Add default IDs for landing and promotions data and ignore node_modules in git

## Testing
- `npm run build`
- `npm run check` *(fails: Property 'datetime' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bcedb915c08330a7d3791059df12cc