### PR TITLE
Align event and game time fields

### DIFF
--- a/server/data/events.json
+++ b/server/data/events.json
@@ -3,8 +3,8 @@
     "id": "event-001",
     "title": "NFL Playoff Party",
     "slug": "nfl-playoff-party",
-    "start": "2025-01-15T18:00:00.000Z",
-    "end": "2025-01-15T23:00:00.000Z",
+    "startDate": "2025-01-15T18:00:00.000Z",
+    "endDate": "2025-01-15T23:00:00.000Z",
     "image": "https://images.unsplash.com/photo-1578662996442-48f60103fc96?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&h=400",
     "description": "Join us for the biggest game of the season! Food specials, drink deals, and prizes throughout the game. Reserve your table early - this one fills up fast!",
     "tags": ["playoff game", "special event"]
@@ -13,8 +13,8 @@
     "id": "event-002", 
     "title": "Acoustic Friday",
     "slug": "acoustic-friday",
-    "start": "2025-01-18T19:00:00.000Z",
-    "end": "2025-01-18T22:00:00.000Z",
+    "startDate": "2025-01-18T19:00:00.000Z",
+    "endDate": "2025-01-18T22:00:00.000Z",
     "image": "https://images.unsplash.com/photo-1493225457124-a3eb161ffa5f?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&h=400",
     "description": "Local acoustic duo performing your favorite classics and modern hits. Perfect background music for dinner and drinks with friends.",
     "tags": ["live music", "acoustic"]
@@ -23,8 +23,8 @@
     "id": "event-003",
     "title": "Weekly Trivia Night",
     "slug": "weekly-trivia-night", 
-    "start": "2025-01-16T20:00:00.000Z",
-    "end": "2025-01-16T22:00:00.000Z",
+    "startDate": "2025-01-16T20:00:00.000Z",
+    "endDate": "2025-01-16T22:00:00.000Z",
     "image": "https://images.unsplash.com/photo-1606092195730-5d7b9af1efc5?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&h=400",
     "description": "Test your knowledge with our weekly trivia competition. Great prizes for winning teams and fun for everyone! Teams of 4-6 people recommended.",
     "tags": ["trivia night", "weekly event"]
@@ -33,8 +33,8 @@
     "id": "event-004",
     "title": "Super Bowl Watch Party",
     "slug": "super-bowl-watch-party",
-    "start": "2025-02-09T17:00:00.000Z", 
-    "end": "2025-02-09T23:30:00.000Z",
+    "startDate": "2025-02-09T17:00:00.000Z",
+    "endDate": "2025-02-09T23:30:00.000Z",
     "image": "https://images.unsplash.com/photo-1574391884720-bfb65e72b3e5?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&h=400",
     "description": "The biggest sports event of the year! Join us for an unforgettable Super Bowl experience with premium viewing, special menu items, and halftime entertainment.",
     "tags": ["super bowl", "championship", "special event"]
@@ -43,8 +43,8 @@
     "id": "event-005",
     "title": "March Madness Bracket Challenge",
     "slug": "march-madness-bracket-challenge",
-    "start": "2025-03-15T12:00:00.000Z",
-    "end": "2025-04-08T23:59:00.000Z",
+    "startDate": "2025-03-15T12:00:00.000Z",
+    "endDate": "2025-04-08T23:59:00.000Z",
     "description": "Join our March Madness bracket challenge! $20 entry fee, winner takes 60% of the pot. Fill out your brackets and watch every game with us.",
     "tags": ["march madness", "bracket challenge", "tournament"]
   }

--- a/server/data/games.json
+++ b/server/data/games.json
@@ -6,7 +6,7 @@
     "awayTeam": "Bills", 
     "homeAbbr": "KC",
     "awayAbbr": "BUF",
-    "datetime": "2025-01-15T20:20:00.000Z",
+    "startTime": "2025-01-15T20:20:00.000Z",
     "channel": "ESPN"
   },
   {
@@ -16,7 +16,7 @@
     "awayTeam": "Celtics",
     "homeAbbr": "LAL", 
     "awayAbbr": "BOS",
-    "datetime": "2025-01-15T22:30:00.000Z",
+    "startTime": "2025-01-15T22:30:00.000Z",
     "channel": "TNT"
   },
   {
@@ -26,7 +26,7 @@
     "awayTeam": "Bruins",
     "homeAbbr": "NYR",
     "awayAbbr": "BOS", 
-    "datetime": "2025-01-15T19:00:00.000Z",
+    "startTime": "2025-01-15T19:00:00.000Z",
     "channel": "ESPN+"
   },
   {
@@ -36,7 +36,7 @@
     "awayTeam": "Nuggets",
     "homeAbbr": "GSW",
     "awayAbbr": "DEN",
-    "datetime": "2025-01-16T21:00:00.000Z", 
+    "startTime": "2025-01-16T21:00:00.000Z",
     "channel": "ESPN"
   },
   {
@@ -46,7 +46,7 @@
     "awayTeam": "Cowboys",
     "homeAbbr": "GB",
     "awayAbbr": "DAL",
-    "datetime": "2025-01-16T16:30:00.000Z",
+    "startTime": "2025-01-16T16:30:00.000Z",
     "channel": "FOX"
   }
 ]

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -97,25 +97,36 @@ export class MemStorage implements IStorage {
       }
       
       // Load events data
-      const eventsData = JSON.parse(await readFile(join(process.cwd(), 'server/data/events.json'), 'utf-8'));
+      const eventsData = JSON.parse(
+        await readFile(join(process.cwd(), 'server/data/events.json'), 'utf-8')
+      );
       for (const event of eventsData) {
         const newEvent: Event = {
-          ...event,
-          start: new Date(event.start),
-          end: new Date(event.end),
+          id: event.id,
+          title: event.title,
+          slug: event.slug,
+          startDate: new Date(event.startDate),
+          endDate: new Date(event.endDate),
           description: event.description || null,
           image: event.image || null,
           tags: Array.isArray(event.tags) ? event.tags : null
         };
         this.events.set(event.id, newEvent);
       }
-      
+
       // Load games data
-      const gamesData = JSON.parse(await readFile(join(process.cwd(), 'server/data/games.json'), 'utf-8'));
+      const gamesData = JSON.parse(
+        await readFile(join(process.cwd(), 'server/data/games.json'), 'utf-8')
+      );
       for (const game of gamesData) {
         const newGame: Game = {
-          ...game,
-          datetime: new Date(game.datetime),
+          id: game.id,
+          league: game.league,
+          homeTeam: game.homeTeam,
+          awayTeam: game.awayTeam,
+          homeAbbr: game.homeAbbr,
+          awayAbbr: game.awayAbbr,
+          startTime: new Date(game.startTime),
           channel: game.channel || null
         };
         this.games.set(game.id, newGame);
@@ -370,38 +381,48 @@ export class DatabaseStorage implements IStorage {
       }
       
       // Load and insert events
-      const eventsData = JSON.parse(await readFile(join(process.cwd(), 'server/data/events.json'), 'utf-8'));
+      const eventsData = JSON.parse(
+        await readFile(join(process.cwd(), 'server/data/events.json'), 'utf-8')
+      );
       for (const event of eventsData) {
         try {
-          await db.insert(eventsTable).values({
-            id: event.id,
-            title: event.title,
-            slug: event.slug,
-            startDate: new Date(event.start),
-            endDate: new Date(event.end),
-            image: event.image || null,
-            description: event.description || null,
-            tags: event.tags || null
-          }).onConflictDoNothing();
+          await db
+            .insert(eventsTable)
+            .values({
+              id: event.id,
+              title: event.title,
+              slug: event.slug,
+              startDate: new Date(event.startDate),
+              endDate: new Date(event.endDate),
+              image: event.image || null,
+              description: event.description || null,
+              tags: event.tags || null
+            })
+            .onConflictDoNothing();
         } catch (e) {
           console.log('Event already exists:', event.id);
         }
       }
-      
+
       // Load and insert games
-      const gamesData = JSON.parse(await readFile(join(process.cwd(), 'server/data/games.json'), 'utf-8'));
+      const gamesData = JSON.parse(
+        await readFile(join(process.cwd(), 'server/data/games.json'), 'utf-8')
+      );
       for (const game of gamesData) {
         try {
-          await db.insert(gamesTable).values({
-            id: game.id,
-            league: game.league,
-            homeTeam: game.homeTeam,
-            awayTeam: game.awayTeam,
-            homeAbbr: game.homeAbbr,
-            awayAbbr: game.awayAbbr,
-            startTime: new Date(game.datetime),
-            channel: game.channel || null
-          }).onConflictDoNothing();
+          await db
+            .insert(gamesTable)
+            .values({
+              id: game.id,
+              league: game.league,
+              homeTeam: game.homeTeam,
+              awayTeam: game.awayTeam,
+              homeAbbr: game.homeAbbr,
+              awayAbbr: game.awayAbbr,
+              startTime: new Date(game.startTime),
+              channel: game.channel || null
+            })
+            .onConflictDoNothing();
         } catch (e) {
           console.log('Game already exists:', game.id);
         }


### PR DESCRIPTION
## Summary
- Map event JSON times to `startDate`/`endDate`
- Map game JSON times to `startTime`
- Use new fields when seeding in-memory and database storage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf10e02488330b407cd120153f161